### PR TITLE
GenEventWeight and PU Correction for 2017

### DIFF
--- a/analyzers/analyzer_base.C
+++ b/analyzers/analyzer_base.C
@@ -245,6 +245,6 @@ void analyzer_base::Init(TChain *tree, Bool_t isitMC, Bool_t domakelog, TString 
    fChain->SetBranchAddress("AOD_eledz", &AOD_eledz, &b_AOD_eledz);
    fChain->SetBranchAddress("AOD_CaloMET_pt", &AOD_CaloMET_pt, &b_AOD_CaloMET_pt);
    fChain->SetBranchAddress("AOD_CaloMET_phi", &AOD_CaloMET_phi, &b_AOD_CaloMET_phi);
-   if(Tsample == "DYJetsToLL_M-50" || Tsample == "ST_s-channel_4f_leptonDecays")fChain->SetBranchAddress("AODGenEventWeight", &AODGenEventWeight, &b_AODGenEventWeight);
+   if(Tsample == "DYJetsToLL_M-50_PU" || Tsample == "DYJetsToLL_M-50" || Tsample == "ST_s-channel_4f_leptonDecays")fChain->SetBranchAddress("AODGenEventWeight", &AODGenEventWeight, &b_AODGenEventWeight);
 
 }

--- a/analyzers/analyzer_config.C
+++ b/analyzers/analyzer_config.C
@@ -56,9 +56,9 @@ void analyzer_config::setConfiguration()
  //TA Out    | -1.759    | -1.773 | -1.773    | -1.773    |  //loggit
 
  // shifted tagging variables             // loggit
- tag_shiftmaxAmax   = 0.75;//0.803; //0.758;  // = 0.75;  // loggit
- tag_shiftminIPsig  = 1.15;//1.270; //1.137;  // = 1.15;  // loggit
- tag_shiftminTA     = -1.75;//-1.710; //-1.773; // = -1.75; // loggit
+ tag_shiftmaxAmax   = 0.789;//0.803; //0.758;  // = 0.75;  // loggit
+ tag_shiftminIPsig  = 1.193;//1.270; //1.137;  // = 1.15;  // loggit
+ tag_shiftminTA     = -1.829;//-1.710; //-1.773; // = -1.75; // loggit
 
  // set which collections                          // loggit 
 // phoid = "Medium"; // "Tight"; "Loose"; //Medium"; // loggit 

--- a/analyzers/analyzer_histograms.C
+++ b/analyzers/analyzer_histograms.C
@@ -574,7 +574,7 @@ Bool_t analyzer_histograms::initAODCaloJetBasicHistograms( TString uncbin )
 	h_AODCaloJetPt                             [i][k] = initSingleHistogramTH1F( hname_AODCaloJetPt                             , "AODCaloJetPt                            ", 50,0,500  ); 
 	h_AODCaloJetEta                            [i][k] = initSingleHistogramTH1F( hname_AODCaloJetEta                            , "AODCaloJetEta                           ", 30,-5,5   ); 
 	h_AODCaloJetPhi                            [i][k] = initSingleHistogramTH1F( hname_AODCaloJetPhi                            , "AODCaloJetPhi                           ", 30,-5,5   ); 
-	h_AODCaloJetAlphaMax                       [i][k] = initSingleHistogramTH1F( hname_AODCaloJetAlphaMax                       , "AODCaloJetAlphaMax                      ", 500, 0, 1.1  ); 
+	h_AODCaloJetAlphaMax                       [i][k] = initSingleHistogramTH1F( hname_AODCaloJetAlphaMax                       , "AODCaloJetAlphaMax                      ", 60, 0, 1.2  ); 
 	h_AODCaloJetAlphaMax2                      [i][k] = initSingleHistogramTH1F( hname_AODCaloJetAlphaMax2                      , "AODCaloJetAlphaMax2                     ", 50, 0, 1.1  ); 
 	h_AODCaloJetAlphaMaxPrime                  [i][k] = initSingleHistogramTH1F( hname_AODCaloJetAlphaMaxPrime                  , "AODCaloJetAlphaMaxPrime                 ", 50, 0, 1.1  ); 
 	h_AODCaloJetAlphaMaxPrime2                 [i][k] = initSingleHistogramTH1F( hname_AODCaloJetAlphaMaxPrime2                 , "AODCaloJetAlphaMaxPrime2                ", 50, 0, 1.1  ); 
@@ -583,10 +583,10 @@ Bool_t analyzer_histograms::initAODCaloJetBasicHistograms( TString uncbin )
 	h_AODCaloJetSumIP                          [i][k] = initSingleHistogramTH1F( hname_AODCaloJetSumIP                          , "AODCaloJetSumIP                         ", 50, -3, 3 ); 
 	h_AODCaloJetSumIPSig                       [i][k] = initSingleHistogramTH1F( hname_AODCaloJetSumIPSig                       , "AODCaloJetSumIPSig                      ", 50, -3, 3 ); 
 	h_AODCaloJetMedianIP                       [i][k] = initSingleHistogramTH1F( hname_AODCaloJetMedianIP                       , "AODCaloJetMedianIP                      ", 50, -3, 3 ); 
-	h_AODCaloJetMedianLog10IPSig               [i][k] = initSingleHistogramTH1F( hname_AODCaloJetMedianLog10IPSig               , "AODCaloJetMedianLog10IPSig              ", 500, -3, 4 ); 
+	h_AODCaloJetMedianLog10IPSig               [i][k] = initSingleHistogramTH1F( hname_AODCaloJetMedianLog10IPSig               , "AODCaloJetMedianLog10IPSig              ", 50, -3, 4 ); 
 	h_AODCaloJetTrackAngle                     [i][k] = initSingleHistogramTH1F( hname_AODCaloJetTrackAngle                     , "AODCaloJetTrackAngle                    ", 50, -3, 3 ); 
 	h_AODCaloJetLogTrackAngle                  [i][k] = initSingleHistogramTH1F( hname_AODCaloJetLogTrackAngle                  , "AODCaloJetLogTrackAngle                 ", 50, -3, 3 ); 
-	h_AODCaloJetMedianLog10TrackAngle          [i][k] = initSingleHistogramTH1F( hname_AODCaloJetMedianLog10TrackAngle          , "AODCaloJetMedianLog10TrackAngle         ", 500, -5, 2 ); 
+	h_AODCaloJetMedianLog10TrackAngle          [i][k] = initSingleHistogramTH1F( hname_AODCaloJetMedianLog10TrackAngle          , "AODCaloJetMedianLog10TrackAngle         ", 50, -5, 2 ); 
 	h_AODCaloJetTotalTrackAngle                [i][k] = initSingleHistogramTH1F( hname_AODCaloJetTotalTrackAngle                , "AODCaloJetTotalTrackAngle               ", 50, -3, 3 ); 
 	h_AODCaloJetMinDR                          [i][k] = initSingleHistogramTH1F( hname_AODCaloJetMinDR                          , "AODCaloJetMinDR                         ", 30, 0, 5 ); 
 //	h_AODCaloJetCSV                            [i][k] = initSingleHistogramTH1F( hname_AODCaloJetCSV                            , "AODCaloJetCSV                           ", 24, -.1, 1.1 ); 

--- a/analyzers/analyzer_loop.C
+++ b/analyzers/analyzer_loop.C
@@ -51,7 +51,6 @@ TFile *outfile_bkgest = 0;
  TFile *outfile_GEW = 0;
  outfile_GEW = TFile::Open(outfilename+"_AODGenEventWeight.root","RECREATE");
  TH1F* h_sum_AODGenEventWeight = new TH1F("h_sum_AODGenEventWeight","h_sum_AODGenEventWeight", 5,0.,5.);
-//std::cout<<"Passed create GEW file" <<std::endl;
  // start looping over entries
  Long64_t nbytes = 0, nb = 0;
  for (Long64_t jentry=0; jentry<nentries;jentry++) {
@@ -85,7 +84,6 @@ TFile *outfile_bkgest = 0;
   shiftCollections(uncbin);
   n_tot++;
   h_sum_AODGenEventWeight->Fill(2, AODGenEventWeight);
-//std::cout<<"Fill Histo" <<std::endl;
   // get lists of "good" electrons, photons, jets
   // idbit, pt, eta, sysbinname
   electron_list    = electron_passID  ( eleidbit,        ele_minPt1, ele_minPt2, ele_maxEta, "");
@@ -363,7 +361,9 @@ TFile *outfile_bkgest = 0;
    setNM1EleZHtree(); 
    NM1EleZHtree->Fill();
   }
-
+  //std::cout<<"PU DoubleEG Weight: "<<PUweight_DoubleEG<<"      Weight:"<<PUWeights_DoubleEG->GetBinContent(PUWeights_DoubleMu->GetBin(AODnTruePU))<<"         Bin:"<<PUWeights_DoubleMu->GetBin(AODnTruePU)<<"    nTruePU: "<<AODnTruePU<<std::endl;
+  //std::cout<<"PU DoubleMu Weight: "<<PUweight_DoubleMu<<std::endl;
+  //std::cout<<"PU MuonEG Weight: "<<PUweight_MuonEG<<std::endl;
   // fill the histograms
   for(unsigned int i=0; i<selbinnames.size(); ++i){
    

--- a/analyzers/analyzer_scalefactors.C
+++ b/analyzers/analyzer_scalefactors.C
@@ -26,7 +26,6 @@ Float_t analyzer_scalefactors::makeEventWeight(Float_t crossSec,
 
   return event_weight;
 }
-
 //----------------------------makePUWeight
 Float_t analyzer_scalefactors::makePUWeight( TString dataset ){
  Int_t tmpbin;

--- a/ntuples/config/crab_template.py
+++ b/ntuples/config/crab_template.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
     #config.Data.useParent             = True
     config.Data.ignoreLocality         = True
-    config.Site.whitelist = ["T2_US*"]
+    config.Site.whitelist = ["T2*"]
 
     def submit(config):
         try:

--- a/ntuples/config/submitcrab.sh
+++ b/ntuples/config/submitcrab.sh
@@ -56,7 +56,8 @@ cp "${subdir}/${msubmitconfig}"  ${thesubdir}
 # sample names to run over
 samples=( \
 # put your samples here, copy from below
-  "Data_DoubleMuon_B"      \
+  "DY50_PU_1"               \
+  "DY50_PU_2"               \
 )
 
 #  "Data_DoubleMuon_F"      \

--- a/ntuples/interface/lldjNtuple.h
+++ b/ntuples/interface/lldjNtuple.h
@@ -244,6 +244,7 @@ class lldjNtuple : public edm::EDAnalyzer {
 
 
   //gen
+  edm::EDGetTokenT<GenEventInfoProduct> AODGenEventInfoLabel_;
   //edm::EDGetTokenT<vector<reco::GenParticle> >     genParticlesCollection_;
 
   TTree   *tree_;

--- a/ntuples/interface/lldjNtuple.h
+++ b/ntuples/interface/lldjNtuple.h
@@ -244,12 +244,14 @@ class lldjNtuple : public edm::EDAnalyzer {
 
 
   //gen
-  edm::EDGetTokenT<GenEventInfoProduct> AODGenEventInfoLabel_;
   //edm::EDGetTokenT<vector<reco::GenParticle> >     genParticlesCollection_;
-
+  edm::EDGetTokenT<GenEventInfoProduct> AODGenEventInfoLabel_;
+  
   TTree   *tree_;
   TH1F    *hEvents_;
   TH1F    *hTTSF_;
+  TH1F    *hGenEventWeightSum_;
+  float   GenEventWeight;
 
   JME::JetResolution            slimmedJetResolution_;
   JME::JetResolutionScaleFactor slimmedJetResolutionSF_;

--- a/ntuples/plugins/lldjNtuple.cc
+++ b/ntuples/plugins/lldjNtuple.cc
@@ -117,6 +117,7 @@ lldjNtuple::lldjNtuple(const edm::ParameterSet& ps) :
   AODTriggerEventToken_           = consumes<trigger::TriggerEvent>(AODTriggerEventLabel_);
 
   // gen
+  AODGenEventInfoLabel_           = consumes <GenEventInfoProduct> (edm::InputTag(std::string("generator")));
   //genParticlesCollection_    = consumes<vector<reco::GenParticle> >    (ps.getParameter<InputTag>("genParticleSrc"));
 
   Service<TFileService> fs;

--- a/ntuples/plugins/lldjNtuple.cc
+++ b/ntuples/plugins/lldjNtuple.cc
@@ -117,13 +117,14 @@ lldjNtuple::lldjNtuple(const edm::ParameterSet& ps) :
   AODTriggerEventToken_           = consumes<trigger::TriggerEvent>(AODTriggerEventLabel_);
 
   // gen
-  AODGenEventInfoLabel_           = consumes <GenEventInfoProduct> (edm::InputTag(std::string("generator")));
   //genParticlesCollection_    = consumes<vector<reco::GenParticle> >    (ps.getParameter<InputTag>("genParticleSrc"));
+  AODGenEventInfoLabel_           = consumes <GenEventInfoProduct> (edm::InputTag(std::string("generator")));
 
   Service<TFileService> fs;
   tree_    = fs->make<TTree>("EventTree", "Event data");
   hTTSF_   = fs->make<TH1F>("hTTSF",      "TTbar scalefactors",   200,  0,   2);
   hEvents_ = fs->make<TH1F>("hEvents",    "total processed events",   1,  0,   2);
+  hGenEventWeightSum_ = fs->make<TH1F>("hGenEventWeightSum",    "Sum of GenEventWeights",   1,  0,   2);
 
  //if(doMiniAOD_){
  // // make branches for tree
@@ -163,41 +164,7 @@ void lldjNtuple::beginRun(edm::Run const& run, edm::EventSetup const& eventsetup
 }
 
 void lldjNtuple::analyze(const edm::Event& e, const edm::EventSetup& es) {
-
- //if(doMiniAOD_){
- // //# https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution
- // slimmedJetResolution_   = JME::JetResolution::get(es, "AK4PFchs_pt");
- // slimmedJetResolutionSF_ = JME::JetResolutionScaleFactor::get(es, "AK4PFchs");
- //
- // fillGlobalEvent(e, es);
- // fillTrigger(e, es);
- // fillPhotons(e, es);
- // fillElectrons(e, es);
- //
- // // muons use vtx for isolation
- // edm::Handle<reco::VertexCollection> vtxHandle;
- // e.getByToken(vtxLabel_, vtxHandle);
- // reco::Vertex vtx;
- // // best-known primary vertex coordinates
- // math::XYZPoint pv(0, 0, 0); 
- // for (vector<reco::Vertex>::const_iterator v = vtxHandle->begin(); v != vtxHandle->end(); ++v) {
- //   // replace isFake() for miniAOD since it requires tracks while miniAOD vertices don't have tracks:
- //   // Vertex.h: bool isFake() const {return (chi2_==0 && ndof_==0 && tracks_.empty());}
- //   bool isFake = -(v->chi2() == 0 && v->ndof() == 0); 
- //
- //   if (!isFake) {
- //     pv.SetXYZ(v->x(), v->y(), v->z());
- //     vtx = *v; 
- //     break;
- //   }   
- // }
- // fillMuons(e, vtx); //muons use vtx for isolation
- //
- // fillJets(e,es);
- // fillMET(e, es);
- //}
-
- if(doAOD_){
+ GenEventWeight = 0.0;
   fillAODEvent(e, es);
   fillAODTrigger(e, es);
   fillAODJets(e, es);
@@ -217,9 +184,10 @@ void lldjNtuple::analyze(const edm::Event& e, const edm::EventSetup& es) {
   fillAODMuons(e, vtx); 
   fillAODMET(e, es);
 
- }
 
  hEvents_->Fill(1.);
+ if (!e.isRealData()) hGenEventWeightSum_->Fill(1, GenEventWeight);
+ else hGenEventWeightSum_->Fill(1, 1);
  tree_->Fill();
 }
 

--- a/ntuples/plugins/lldjNtuple_AODevent.cc
+++ b/ntuples/plugins/lldjNtuple_AODevent.cc
@@ -17,7 +17,12 @@ Int_t       AODnVtx_;
 Int_t       AODnGoodVtx_;
 Int_t       AODnTrksPV_;
 Bool_t      AODisPVGood_;
+Float_t     AODGenEventWeight_;
 
+vector<int>       AODBunchXing_;
+vector<int>       AODnPU_;
+Int_t             AOD0thnPU_;
+vector<int>       AODnPUMean_;
 
 void lldjNtuple::branchesAODEvent(TTree* tree) {
 
@@ -31,11 +36,20 @@ void lldjNtuple::branchesAODEvent(TTree* tree) {
   tree->Branch("AODnGoodVtx",             &AODnGoodVtx_);
   tree->Branch("AODnTrksPV",              &AODnTrksPV_);
   tree->Branch("AODisPVGood",             &AODisPVGood_);
+  tree->Branch("AODGenEventWeight",       &AODGenEventWeight_);
 
+  tree->Branch("AODBunchXing",       &AODBunchXing_);
+  tree->Branch("AODnPU",             &AODnPU_);
+  tree->Branch("AOD0thnPU",          &AOD0thnPU_);
+  tree->Branch("AODnPUMean",         &AODnPUMean_);
 }
 
 void lldjNtuple::fillAODEvent(const edm::Event& e, const edm::EventSetup& es) {
 
+  AODBunchXing_.clear();
+  AODnPU_      .clear();
+  AODnPUMean_  .clear();
+ 
   AODrun_    = e.id().run();
   AODevent_  = e.id().event();
   AODlumis_  = e.luminosityBlock();
@@ -47,9 +61,26 @@ void lldjNtuple::fillAODEvent(const edm::Event& e, const edm::EventSetup& es) {
    e.getByToken(AODpuCollection_, AODpuInfoHandle);
    if ( AODpuInfoHandle->size() > 0 ){
     AODnTruePU_ = AODpuInfoHandle->at(0).getTrueNumInteractions() ;
-    //AODnTruePU_ = AODpuInfoHandle->at(1).getTrueNumInteractions() ;
    }
+  
+
+  int BunchXing  = -99999;
+  int nPU        = -99999;
+  int nPUMean    = -99999;
+  AOD0thnPU_     = -99999;
+  for(const PileupSummaryInfo &pu : *AODpuInfoHandle){
+    BunchXing  = pu.getBunchCrossing();
+    nPU        = pu.getPU_NumInteractions();
+    nPUMean    = pu.getTrueNumInteractions();
+    AODBunchXing_ .push_back(BunchXing); 
+    AODnPU_       .push_back(nPU      ); 
+    AODnPUMean_   .push_back(nPUMean  ); 
+   
+    //Save separately the 0th value
+    if(BunchXing==0) AOD0thnPU_= nPU;
   }
+  }//!e.isRealData()
+
 
 
   edm::Handle<edm::View<reco::Vertex>  >  AODVertexHandle;
@@ -80,6 +111,8 @@ void lldjNtuple::fillAODEvent(const edm::Event& e, const edm::EventSetup& es) {
    AODnVtx_++;
   } // if AODVertexHandle->at(k).isValid()
   else {edm::LogWarning("lldjNtuple") << "Primary vertices info not unavailable";}
-
   }
+  edm::Handle<GenEventInfoProduct>  AODGenEventInfoHandle;
+  e.getByToken(AODGenEventInfoLabel_, AODGenEventInfoHandle);
+  AODGenEventWeight_ = AODGenEventInfoHandle->weight();
 }

--- a/ntuples/plugins/lldjNtuple_AODevent.cc
+++ b/ntuples/plugins/lldjNtuple_AODevent.cc
@@ -23,7 +23,6 @@ vector<int>       AODBunchXing_;
 vector<int>       AODnPU_;
 Int_t             AOD0thnPU_;
 vector<int>       AODnPUMean_;
-
 void lldjNtuple::branchesAODEvent(TTree* tree) {
 
   tree->Branch("run",     	       &AODrun_);
@@ -112,7 +111,10 @@ void lldjNtuple::fillAODEvent(const edm::Event& e, const edm::EventSetup& es) {
   } // if AODVertexHandle->at(k).isValid()
   else {edm::LogWarning("lldjNtuple") << "Primary vertices info not unavailable";}
   }
+  if (!e.isRealData()){
   edm::Handle<GenEventInfoProduct>  AODGenEventInfoHandle;
   e.getByToken(AODGenEventInfoLabel_, AODGenEventInfoHandle);
-  AODGenEventWeight_ = AODGenEventInfoHandle->weight();
+  GenEventWeight =AODGenEventInfoHandle->weight();
+  AODGenEventWeight_ = GenEventWeight;
+  }
 }

--- a/ntuples/plugins/lldjNtuple_AODjets.cc
+++ b/ntuples/plugins/lldjNtuple_AODjets.cc
@@ -628,7 +628,6 @@ void lldjNtuple::fillAODJets(const edm::Event& e, const edm::EventSetup& es) {
    && iJet->energyFractionHadronic()<=0.9)  passID = true; 
 
   if(iJet->pt()<20.0 || fabs(iJet->eta())>2.4 || !passID) continue;
-
   // caloJetTrackIDs is a vector of ints where each int is the 
   // index of a track passing deltaR requirement to this jet
   // out of the master track record of tracks passing basic selections


### PR DESCRIPTION
Adding the GenEventWeights back into ntuples.
Adding the PU fix needed to correctly make PU weights

Note there is a problem with the GenEventWeightSum histogram made in the ntuples. It alway stores 1. I need to fix it, but don't see the problem yet. However, this can be merged without the fix as the GenEventWeights are saved individually as well.